### PR TITLE
Missing main entry point for webpack/browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "famous-lagometer",
   "version": "0.0.1",
+  "main": "./Lagometer.js",
   "homepage": "https://github.com/IjzerenHein/famous-lagometer",
   "author": {
     "name": "Hein Rutjes <hrutjes@gmail.com>"


### PR DESCRIPTION
Only tested with webpack, but the same thing goes.
